### PR TITLE
Fix check action

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -37,11 +37,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Run linter
-        uses: wearerequired/lint-action@v2
-        with:
-          eslint: true
-
       - name: Run tests
         run: pnpm test
 


### PR DESCRIPTION
- Target `main` branch instead od `master`
- Don't run when pushing to `main` - the branch is already protected by requiring the check to complete before merging